### PR TITLE
make "old_files" dir importable in pyraf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,9 @@ classifier =
 
 [files]
 packages_root = lib
-packages = pyraf
+packages =
+	pyraf
+	pyraf.old_files
 data_files =
 	pyraf = data/blankcursor.xbm data/epar.optionDB data/pyraflogo_rgb_web.gif data/ipythonrc-pyraf
 	pyraf/clcache = data/clcache/*


### PR DESCRIPTION
Change the packages attr in setup.cfg to add `old_files` dir, and add the ``__init__.py`` file (empty).