### PR TITLE
fix to subproc_tests.test() to not use "is" so casually

### DIFF
--- a/lib/pyraf/old_files/subproc_tests.py
+++ b/lib/pyraf/old_files/subproc_tests.py
@@ -17,7 +17,7 @@ def test(fout=sys.stdout):
     try:
         # grab stderr just to make sure the error message still appears
         b = Subprocess('/', 1, expire_noisily=1)
-        assert b.wait(1) is True, 'How is this still alive after 1 sec?'
+        assert b.wait(1), 'How is this still alive after 1 sec?'
     except SubprocessError:
         print("\t...yep, it failed.")
     print('\tWrite, then read, two newline-terminated lines, using readline:')


### PR DESCRIPTION
This test is failing bc Subprocess.wait() returns an int, but we are checking for True (via `is`).  Not really sure how this was ever passing before, unless perhaps Py27 was casting that for us without our knowledge.

I have confirmed manually that the new code does The Right Thing here.  It should only throw the assert if `wait()` returns 0.